### PR TITLE
uhd: fixed USRP sink tagged stream gap handling

### DIFF
--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -635,9 +635,6 @@ namespace gr {
         if (my_tag_count >= max_count) {
           break;
         }
-        else if (not pmt::is_null(_length_tag_key) and my_tag_count > samp0_count + _nitems_to_send) {
-          break;
-        }
 
         /* I. Tags that can only be on the first sample of a burst
          *


### PR DESCRIPTION
Fixed a tag gap handling issue caused by an IF statement in tag_work. If length_tag is specified in the usrp_sink constructor but no tag is found on the very first sample, usrp_sink will spin forever printing "tG" and it will never send samples. An example of a situation in which this happens is when a block with history inserts samples before the data stream, such as a filter, so the very first length_tag may not be found until several samples later. Removing this check fixed the issue for me, and Martin said it shouldn't affect his tagged commands logic. Link to GR issue #708: http://gnuradio.org/redmine/issues/708
